### PR TITLE
Add a default value to the repository attribute

### DIFF
--- a/lib/Dist/Zilla/PluginBundle/SHLOMIF.pm
+++ b/lib/Dist/Zilla/PluginBundle/SHLOMIF.pm
@@ -115,6 +115,7 @@ has github_name => (
 has repository => (
     is  => 'ro',
     isa => 'Str',
+    default => 'github',
 );
 
 for my $attr (qw(repository_type repository_url repository_web)) {


### PR DESCRIPTION
This should solve problems like [this](https://github.com/shlomif/perl-XML-SemanticDiff/commit/c02f8cd29f2051d16d46c563eaaaac5d1e73a4d3) at the root.
